### PR TITLE
Fix #5 Long Names and Spaces in Names not working with DOSBOX

### DIFF
--- a/src/commands/assemble.ts
+++ b/src/commands/assemble.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { existsSync } from 'fs';
 import { join } from 'path';
 
-export async function assemble() {
+export async function assemble(outputFileBaseNameWithoutExt?: string) {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         vscode.window.showErrorMessage('No active text editor found');
@@ -23,16 +23,17 @@ export async function assemble() {
     const configs = vscode.workspace.getConfiguration('nasm-tools');
     const nasmCommand = configs.get('nasmCommand');
 
+    const fileDir = document.fileName.split('\\').slice(0, -1).join('\\');
     const fileNameWithoutExt = document.fileName.split('.').slice(0, -1).join('.');
-    const fileDir = fileNameWithoutExt.split('\\').slice(0, -1).join('\\');
+    let outputFileNameWithoutExt = outputFileBaseNameWithoutExt ? fileDir + "\\" + outputFileBaseNameWithoutExt : fileNameWithoutExt;
     let terminal = vscode.window.createTerminal('NASM Cleanup');
     terminal.sendText(`cd "${fileDir}"`);
     // Delete Previous Files
-    if (existsSync(join(fileNameWithoutExt + ".com"))) {
-        terminal.sendText(`del "${fileNameWithoutExt}.com"`);
+    if (existsSync(join(outputFileNameWithoutExt + ".com"))) {
+        terminal.sendText(`del "${outputFileNameWithoutExt}.com"`);
     }
-    if (existsSync(join(fileNameWithoutExt + ".lst"))) {
-        terminal.sendText(`del "${fileNameWithoutExt}.lst"`);
+    if (existsSync(join(outputFileNameWithoutExt + ".lst"))) {
+        terminal.sendText(`del "${outputFileNameWithoutExt}.lst"`);
     }
     terminal.sendText('exit');
     while (terminal.exitStatus === undefined) {
@@ -40,18 +41,18 @@ export async function assemble() {
     }
     terminal = vscode.window.createTerminal('NASM Assemble', nasmCommand as string, [
         `${document.fileName}`,
-        "-o", `${fileNameWithoutExt}.com`,
-        "-l", `${fileNameWithoutExt}.lst`
+        "-o", `${outputFileNameWithoutExt}.com`,
+        "-l", `${outputFileNameWithoutExt}.lst`
     ]);
     while (terminal.exitStatus === undefined) {
         await new Promise(resolve => setTimeout(resolve, 500));
     }
-    if (existsSync(join(fileNameWithoutExt + ".com"))) {
+    if (existsSync(join(outputFileNameWithoutExt + ".com"))) {
         vscode.window.showInformationMessage('Assembly Successful');
         return true;
     } else {
         vscode.window.showErrorMessage('Assembly Failed, See LST File for Details');
-        vscode.workspace.openTextDocument(join(fileNameWithoutExt + ".lst")).then(doc => {
+        vscode.workspace.openTextDocument(join(outputFileNameWithoutExt + ".lst")).then(doc => {
             vscode.window.showTextDocument(doc);
         });
         return false;

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,7 +3,7 @@ import { assemble } from "./assemble";
 import { join } from 'path';
 
 export async function run(debugMode = false) {
-    if (!await assemble()) {
+    if (!await assemble("runner")) {
         return false;
     }
 
@@ -14,8 +14,7 @@ export async function run(debugMode = false) {
 
     let document = editor!.document;
     const fileDir = document.fileName.split('\\').slice(0, -1).join('\\');
-    const fileBaseName = document.fileName.split('\\').slice(-1)[0];
-    const fileBaseNameWithoutExt = fileBaseName.split('.').slice(0, -1).join('.');
+    const fileBaseNameWithoutExt = "runner";
 
     if (debugMode) {
         const path = join(vscode.extensions.getExtension("nottahaali.nasm-tools")!.extensionPath, "public");


### PR DESCRIPTION
Fixes #5

- Added an optional parameter for base file name in assemble function
- Passed "runner" as base file name to assemble function when run or debug.
- Used runner.com in DOSBOX