### PR TITLE
Fix Not Working with Older Versions of VS Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/NotTahaAli"
   },
   "engines": {
-    "vscode": "^1.92.0"
+    "vscode": "^1.46.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #21
- Set Minimum Engine Version to 1.46.0